### PR TITLE
Change orbit -> astro_pi_orbit

### DIFF
--- a/en/step_2.md
+++ b/en/step_2.md
@@ -49,11 +49,40 @@ barycentric = mars.at(ts.now())
 print(barycentric)
 ```
 
-We provide the `orbit` flight library (available in the replay tool and on the Astro Pis) to help with finding the current location of the ISS.
+This snippet works but the ephemeris file (`de421.bsp`) is too big to submit in your final payload! To get around this, import the ephemeris from the `astro_pi_orbit` library, which will take care of importing the file for you:
+
+```python
+from skyfield.api import load
+from astro_pi_orbit import de421
+
+planets = de421
+mars = planets['Mars Barycenter']
+ts = load.timescale()
+barycentric = mars.at(ts.now())
+print(barycentric)
+```
 
 #### Documentation
 
 - [rhodesmill.org/skyfield](https://rhodesmill.org/skyfield/)
+
+--- /collapse ---
+
+--- collapse ---
+---
+title: astro_pi_orbit
+---
+#### Usage
+
+The `astro_pi_orbit` library provides a collection of functions to simplify
+certain the code required for certain use cases. It can be used to:
+
+1) Find the current location of the ISS
+2) Access the `de421` or `de440s` ephemeris files (the files are too big to supply by yourself)
+3) Access the Astro Pi's PIR motion sensor
+
+#### Documentation
+- [https://github.com/astro-pi/astro-pi-orbit]
 
 --- /collapse ---
 

--- a/en/step_3.md
+++ b/en/step_3.md
@@ -153,12 +153,12 @@ Update your `main.py` file to capture images or Sense HAT data in real time.
 
 ### Finding the location of the ISS
 
-You will be able to download up to 42 pictures that you take on the ISS. It can be nice to know where exactly an image was taken, and this is something you can do easily with the `orbit` and `exif` libraries available on the Astro Pis.
+You will be able to download up to 42 pictures that you take on the ISS. It can be nice to know where exactly an image was taken, and this is something you can do easily with the `astro_pi_orbit` and `exif` libraries available on the Astro Pis.
 
 The following is an example of a program that will, when run using the Astro Pi Replay Tool, create a new image called `gps_image1.jpg`. The `picamzero` library will have set the Exif metadata for the image to include the current latitude and longitude of the ISS.
 
 ```Python
-from orbit import ISS
+from astro_pi_orbit import ISS
 from picamzero import Camera
 
 iss = ISS()

--- a/en/step_7.md
+++ b/en/step_7.md
@@ -10,15 +10,15 @@ If you do not know how to compress your project folder into a zip file, speak to
 
 Your zip file must not be more than 3MB in size, unless it includes a .tflite model, in which case it is allowed to be up to 7MB in size to accommodate the size of the model. This means, for example, that you cannot supply your own ephemeris files (e.g. [de421.bsp](https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de421.bsp) or [de440s.bsp](https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440s.bsp)), since they are above the size limit.
 
-Both `de421.bsp` and `de440s.bsp` files are available on the Astro Pis. If your program needs them, you can access them via the included `orbit` library, as seen in the following code:
+Both `de421.bsp` and `de440s.bsp` files are available on the Astro Pis. If your program needs them, you can access them via the included `astro_pi_orbit` library, as seen in the following code:
 
 ```Python
-from orbit import de421, de440s
+from astro_pi_orbit import de421, de440s
 print(de421)
 print(de440s)
 ```
 
-You will need to run this snippet using the Astro Pi Replay tool in order to access the `orbit` library.
+If you are not using a Raspberry Pi you will need to run this snippet using the Astro Pi Replay tool in order to access the `astro_pi_orbit` library.
 
 --- task ---
 


### PR DESCRIPTION
This PR changes the creator to guide to use the library name `astro_pi_orbit` instead of `orbit`, as we will be releasing the library to PyPI using this name.